### PR TITLE
Leitura com intervalo definido

### DIFF
--- a/src/RemoteIO.cpp
+++ b/src/RemoteIO.cpp
@@ -942,19 +942,33 @@ void RemoteIO::updatePinInput(String ref)
 {
   int pinRef = setIO[ref]["pin"].as<int>();
   String typeRef = setIO[ref]["Mode"].as<String>();
-  int valueRef;
+  int delayTime = setIO[ref]["delay"].as<int>() * 1000; // variável de configuração sincronizada com a plataforma
+  int timestamp = setIO[ref]["timestamp"].as<int>();  // variável de configuração local, dessincronizada
 
-  if (typeRef == "INPUT" || typeRef == "INPUT_PULLDOWN" || typeRef == "INPUT_PULLUP")
+  // garantir pelo menos 5 seg de delay
+  if (delayTime < 5000) 
   {
-    valueRef = digitalRead(pinRef);
-    if (connection_state == CONNECTED) espPOST(appPostData, ref, String(valueRef));
-    else if (anchored) localHttpUpdateMsg(ref, String(valueRef));
+    delayTime = 5000; // ms
+    setIO[ref]["delay"] = 5; // s
   }
-  else if (typeRef == "INPUT_ANALOG")
+
+  if (millis() - timestamp >= delayTime)
   {
-    float value = analogRead(pinRef);
-    if (connection_state == CONNECTED) espPOST(appPostData, ref, String(value));
-    else if (anchored) localHttpUpdateMsg(ref, String(value));
+    setIO[ref]["timestamp"] = millis();
+    
+    // executa ação de leitura conforme tipo de variável ou processo utilizado
+    if (typeRef == "INPUT" || typeRef == "INPUT_PULLDOWN" || typeRef == "INPUT_PULLUP")
+    {
+      int valueRef = digitalRead(pinRef);
+      if (connection_state == CONNECTED) espPOST(ref, String(valueRef));
+      else if (anchored) localHttpUpdateMsg(ref, String(valueRef));
+    }
+    else if (typeRef == "INPUT_ANALOG")
+    {
+      float valueRef = analogRead(pinRef);
+      if (connection_state == CONNECTED) espPOST(ref, String(valueRef));
+      else if (anchored) localHttpUpdateMsg(ref, String(valueRef));
+    }
   }
 }
 


### PR DESCRIPTION
Intervalo definido pela plataforma. Se o valor não existir ou for menor que 5 segundos, adota o valor 5 para atender ao requisito mínimo.

Testado e funcionando (com valores criados localmente).

Implementação : Para cada ref do tipo INPUT no dispositivo, haverão dois novos parâmetros no documento de configuração “setIO”.

- setIO[ref][“delay”] → parâmetro sincronizado com a configuração de dispositivo da plataforma, vai necessitar de alterações no back e front. Se o parâmetro não for encontrado no documento recebido na autenticação,  será criado localmente com o valor 5 (segundos), requisito mínimo especificado na tarefa.

- setIO[ref][“timestamp”] → armazena localmente o timestamp da última leitura da ref input, para verificação de passagem do intervalo de tempo definido. Parâmetro criado no documento durante a primeira execução de leitura.