### PR TITLE
Alteração do nome da biblioteca

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# RemoteIO
+# ESP32RemoteIO
 
 Biblioteca para comunicação entre dispositivos [espressif32](https://www.espressif.com/en/products/socs/esp32) e plataforma em nuvem [NodeIoT](https://nodeiot.app.br/).
 
 Possibilita a leitura de sensores e acionamento de atuadores em tempo real, com visualização de dados e ações de comando via dashboards web/mobile.
 
 ## Índice
-- [RemoteIO](#remoteio)
+- [ESP32RemoteIO](#esp32remoteio)
   - [Índice](#índice)
   - [Requisitos](#requisitos)
   - [Instalação](#instalação)
@@ -44,7 +44,7 @@ board = ...
 framework = arduino
 
 # latest stable version
-lib_deps = gkraemer-niot@RemoteIO
+lib_deps = gkraemer-niot@ESP32RemoteIO
 ```
 
 ## Primeiro uso
@@ -60,7 +60,7 @@ Com os passos abaixo você poderá fazer a primeira interação de um hardware [
 - Como sugestão, adicione ao seu dispositivo uma variável para controlar, se disponível, o led embutido (built-in) no PCB do seu hardware. Defina uma referência (Ref) para facilitar a identificação dessa variável no firmware (caso deseje desenvolver outras operações com ela), além de um nome (Variável) para visualização na plataforma. Nas configurações da variável, selecione o modo OUTPUT e informe o pino que controla o led (usualmente o pino 2, verifique documentação da fabricante para mais informações). Salve as configurações do dispositivo.
 - Copie o código do exemplo quickStart.ino abaixo e cole no arquivo principal do projeto em sua IDE. 
 ```ini
-#include <RemoteIO.h>
+#include <ESP32RemoteIO.h>
 
 RemoteIO device1;
 

--- a/examples/quickStart.ino
+++ b/examples/quickStart.ino
@@ -11,7 +11,7 @@
 
 /* Veja a documentação xxx para informações mais detalhadas sobre esse exemplo */
 
-#include <RemoteIO.h>
+#include <ESP32RemoteIO.h>
 
 RemoteIO device1;
 

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-    "name": "RemoteIO",
+    "name": "ESP32RemoteIO",
     "version": "1.0.6",
     "description": "Basic library for communication with cloud based IoT platform NodeIoT, sensors usage and product development. Communicates with NodeIoT to provide real time sensor readings and command actions through web dashboards.",
     "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=RemoteIO
+name=ESP32RemoteIO
 version=1.0.6
 author=gkraemer-niot
 maintainer=gkraemer-niot <guilherme.kraemer@nodeiot.com.br>


### PR DESCRIPTION
Alteração do nome da biblioteca, por solicitação do Christofer e Conrado, para adotar o padrão da ESP8266RemoteIO.

Faltava atualizar alguns arquivos auxiliares que eu havia deixado passar sem perceber.